### PR TITLE
Configure Java versions to update CPE info

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -20,6 +20,7 @@ dependencies:
 - name:            JDK 8
   id:              jdk
   version_pattern: "8(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jdk_x64_linux_.+_openj9-.+.tar.gz
@@ -30,6 +31,7 @@ dependencies:
 - name:            JRE 8
   id:              jre
   version_pattern: "8(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jre_x64_linux_.+_openj9-.+.tar.gz
@@ -40,6 +42,7 @@ dependencies:
 - name:            JDK 11
   id:              jdk
   version_pattern: "11(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jdk_x64_linux_.+_openj9-.+.tar.gz
@@ -50,6 +53,7 @@ dependencies:
 - name:            JRE 11
   id:              jre
   version_pattern: "11(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jre_x64_linux_.+_openj9-.+.tar.gz
@@ -60,6 +64,7 @@ dependencies:
 - name:            JDK 17
   id:              jdk
   version_pattern: "17(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jdk_x64_linux_.+_openj9-.+.tar.gz
@@ -70,6 +75,7 @@ dependencies:
 - name:            JRE 17
   id:              jre
   version_pattern: "17(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
   with:
     glob: ibm-semeru-open-jre_x64_linux_.+_openj9-.+.tar.gz

--- a/.github/workflows/update-jdk-11.yml
+++ b/.github/workflows/update-jdk-11.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jdk-17.yml
+++ b/.github/workflows/update-jdk-17.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jdk-8.yml
+++ b/.github/workflows/update-jdk-8.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jdk
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jre-11.yml
+++ b/.github/workflows/update-jre-11.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jre
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jre-17.yml
+++ b/.github/workflows/update-jre-17.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jre
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""

--- a/.github/workflows/update-jre-8.yml
+++ b/.github/workflows/update-jre-8.yml
@@ -90,7 +90,7 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
                 ID: jre
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: ""


### PR DESCRIPTION
## Summary

Eclipse OpenJ9 has a slightly different CPE format. This change will allow the update script to update the CPE info for Eclipse OpenJ9.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
