### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/eclipse-openj9`
 
-The Paketo Eclipse OpenJ9 Buildpack is a Cloud Native Buildpack that provides the Eclipse OpenJ9 implementations of JREs and JDKs.
+The Paketo Buildpack for Eclipse OpenJ9 is a Cloud Native Buildpack that provides the Eclipse OpenJ9 implementations of JREs and JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/eclipse-openj9"
   id = "paketo-buildpacks/eclipse-openj9"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Eclipse OpenJ9 Buildpack"
+  name = "Paketo Buildpack for Eclipse OpenJ9"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Eclipse OpenJ9 Buildpack' to 'Paketo Buildpack for Eclipse OpenJ9'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
