### PR TITLE
Add ARM64 Support

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -111,3 +111,100 @@ dependencies:
     repository: semeru21-binaries
     tag_filter: jdk(.*21.*)
     token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+# ARM64
+- name:            JDK 8 ARM64
+  id:              jdk
+  version_pattern: "^8(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru8-binaries
+    tag_filter: jdk(.*8.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JRE 8 ARM64
+  id:              jre
+  version_pattern: "^8(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru8-binaries
+    tag_filter: jdk(.*8.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JDK 11 ARM64
+  id:              jdk
+  version_pattern: "^11(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru11-binaries
+    tag_filter: jdk(.*11.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JRE 11 ARM64
+  id:              jre
+  version_pattern: "^11(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru11-binaries
+    tag_filter: jdk(.*11.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JDK 17 ARM64
+  id:              jdk
+  version_pattern: "^17(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru17-binaries
+    tag_filter: jdk(.*17.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JRE 17 ARM64
+  id:              jre
+  version_pattern: "^17(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru17-binaries
+    tag_filter: jdk(.*17.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JDK 21 ARM64
+  id:              jdk
+  version_pattern: "^21(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru21-binaries
+    tag_filter: jdk(.*21.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+- name:            JRE 21 ARM64
+  id:              jre
+  version_pattern: "^21(?:\\.[\\d]+(?:\\.[\\d]+)?)?"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+"
+  uses:            docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+  with:
+    glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+    owner: ibmruntimes
+    repository: semeru21-binaries
+    tag_filter: jdk(.*21.*)
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -6,6 +6,9 @@ codeowners:
 - path:  "*"
   owner: "@paketo-buildpacks/java-maintainers"
 
+helpers:
+  "bin/helper": "github.com/paketo-buildpacks/libjvm/cmd/helper"
+
 package:
   repositories:    ["docker.io/paketobuildpacks/eclipse-openj9", "gcr.io/paketo-buildpacks/eclipse-openj9"]
   register:       true

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -188,7 +188,7 @@ jobs:
                 else
                   pack -v buildpack package \
                     "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}"
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 PACKAGES: docker.io/paketobuildpacks/eclipse-openj9 gcr.io/paketo-buildpacks/eclipse-openj9

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -116,7 +116,7 @@ jobs:
                 export CGO_ENABLED=0
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
-                  BP_DEBUG=true create-package \
+                  create-package \
                     --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -116,7 +116,7 @@ jobs:
                 export CGO_ENABLED=0
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
-                  create-package \
+                  BP_DEBUG=true create-package \
                     --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -173,7 +173,7 @@ jobs:
                 else
                   pack -v buildpack package \
                     "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}"
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 FORMAT: image

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -103,7 +103,7 @@ jobs:
                 export CGO_ENABLED=0
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
-                  BP_DEBUG=true create-package \
+                  create-package \
                     --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -178,7 +178,7 @@ jobs:
               env:
                 FORMAT: image
                 PACKAGES: test
-                TTL_SH_PUBLISH: "true"
+                TTL_SH_PUBLISH: "false"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -178,6 +178,7 @@ jobs:
               env:
                 FORMAT: image
                 PACKAGES: test
+                TTL_SH_PUBLISH: "true"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -103,7 +103,7 @@ jobs:
                 export CGO_ENABLED=0
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
-                  create-package \
+                  BP_DEBUG=true create-package \
                     --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \

--- a/.github/workflows/pb-update-jdk-11-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-11-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JDK 11 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru11-binaries
+                tag_filter: jdk(.*11.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jdk
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^11(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JDK 11 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-11-arm-64
+                commit-message: |-
+                    Bump JDK 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JDK 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JDK 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jdk-17-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-17-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JDK 17 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru17-binaries
+                tag_filter: jdk(.*17.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jdk
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^17(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JDK 17 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-17-arm-64
+                commit-message: |-
+                    Bump JDK 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JDK 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JDK 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jdk-21-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-21-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JDK 21 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru21-binaries
+                tag_filter: jdk(.*21.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jdk
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^21(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JDK 21 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-21-arm-64
+                commit-message: |-
+                    Bump JDK 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JDK 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JDK 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jdk-8-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-8-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JDK 8 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jdk_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru8-binaries
+                tag_filter: jdk(.*8.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jdk
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^8(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JDK 8 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-8-arm-64
+                commit-message: |-
+                    Bump JDK 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JDK 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JDK 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jre-11-arm-64.yml
+++ b/.github/workflows/pb-update-jre-11-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JRE 11 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru11-binaries
+                tag_filter: jdk(.*11.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jre
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^11(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JRE 11 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jre-11-arm-64
+                commit-message: |-
+                    Bump JRE 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JRE 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JRE 11 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jre-17-arm-64.yml
+++ b/.github/workflows/pb-update-jre-17-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JRE 17 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru17-binaries
+                tag_filter: jdk(.*17.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jre
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^17(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JRE 17 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jre-17-arm-64
+                commit-message: |-
+                    Bump JRE 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JRE 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JRE 17 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jre-21-arm-64.yml
+++ b/.github/workflows/pb-update-jre-21-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JRE 21 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru21-binaries
+                tag_filter: jdk(.*21.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jre
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^21(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JRE 21 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jre-21-arm-64
+                commit-message: |-
+                    Bump JRE 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JRE 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JRE 21 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jre-8-arm-64.yml
+++ b/.github/workflows/pb-update-jre-8-arm-64.yml
@@ -1,0 +1,107 @@
+name: Update JRE 8 ARM64
+"on":
+    schedule:
+        - cron: 0 5 * * 1-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Buildpack Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v5
+              with:
+                go-version: "1.20"
+            - name: Install update-buildpack-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
+            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+              with:
+                crane-version: 0.19.0
+                yj-version: 5.1.0
+            - uses: actions/checkout@v4
+            - id: dependency
+              uses: docker://ghcr.io/paketo-buildpacks/actions/ibm-semeru-dependency:main
+              with:
+                arch: arm64
+                glob: ibm-semeru-open-jre_aarch64_linux_.+_openj9-.+.tar.gz
+                owner: ibmruntimes
+                repository: semeru8-binaries
+                tag_filter: jdk(.*8.*)
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+            - name: Update Buildpack Dependency
+              id: buildpack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
+                ARCH=${ARCH:-amd64}
+                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
+
+                if [ -z "$OLD_VERSION" ]; then
+                  ARCH="" # empty means noarch
+                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
+                fi
+
+                update-buildpack-dependency \
+                  --buildpack-toml buildpack.toml \
+                  --id "${ID}" \
+                  --arch "${ARCH}" \
+                  --version-pattern "${VERSION_PATTERN}" \
+                  --version "${VERSION}" \
+                  --cpe-pattern "${CPE_PATTERN:-}" \
+                  --cpe "${CPE:-}" \
+                  --purl-pattern "${PURL_PATTERN:-}" \
+                  --purl "${PURL:-}" \
+                  --uri "${URI}" \
+                  --sha256 "${SHA256}" \
+                  --source "${SOURCE_URI}" \
+                  --source-sha256 "${SOURCE_SHA256}"
+
+                git add buildpack.toml
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
+                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+              env:
+                ARCH: arm64
+                CPE: ${{ steps.dependency.outputs.cpe }}
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+'
+                ID: jre
+                PURL: ${{ steps.dependency.outputs.purl }}
+                PURL_PATTERN: ""
+                SHA256: ${{ steps.dependency.outputs.sha256 }}
+                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
+                SOURCE_URI: ${{ steps.dependency.outputs.source }}
+                URI: ${{ steps.dependency.outputs.uri }}
+                VERSION: ${{ steps.dependency.outputs.version }}
+                VERSION_PATTERN: ^8(?:\.[\d]+(?:\.[\d]+)?)?
+            - uses: peter-evans/create-pull-request@v6
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps `JRE 8 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jre-8-arm-64
+                commit-message: |-
+                    Bump JRE 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+
+                    Bumps JRE 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump JRE 8 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 bin/
+linux/
 dependencies/
 package/
 scratch/
+

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -242,5 +242,141 @@ api = "0.7"
       type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
       uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
 
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "OpenJ9 JDK"
+    purl = "pkg:generic/ibmruntimes/semeru-jdk@8.0.402?arch=arm64"
+    sha256 = "eee642d945d249f9aa2bba0b788a7d79d4989a32205b18e6bb075b50e77d700a"
+    source = "https://github.com/ibmruntimes/semeru8-binaries/archive/refs/tags/jdk8u402-b06_openj9-0.43.0.tar.gz"
+    source-sha256 = "859745cc715bd21f770c59896e619bad431b13d507359e35f5282d57f812e0af"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_8u402b06_openj9-0.43.0.tar.gz"
+    version = "8.0.402"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jre"
+    name = "OpenJ9 JRE"
+    purl = "pkg:generic/ibmruntimes/semeru-jre@8.0.402?arch=arm64"
+    sha256 = "4921671d26754483f096007cfb537922f1b190ca471aaebda6eccdefe91f7fb0"
+    source = "https://github.com/ibmruntimes/semeru8-binaries/archive/refs/tags/jdk8u402-b06_openj9-0.43.0.tar.gz"
+    source-sha256 = "859745cc715bd21f770c59896e619bad431b13d507359e35f5282d57f812e0af"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_8u402b06_openj9-0.43.0.tar.gz"
+    version = "8.0.402"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "OpenJ9 JDK"
+    purl = "pkg:generic/ibmruntimes/semeru-jdk@11.0.22?arch=arm64"
+    sha256 = "8462e525d9fb3ac0d1a3915f859175450da58958a1257cb37fe9cbde57c03eb8"
+    source = "https://github.com/ibmruntimes/semeru11-binaries/archive/refs/tags/jdk-11.0.22+7_openj9-0.43.0.tar.gz"
+    source-sha256 = "8d30c077e9c88d9b184d23575744c462a3fbce9415d0ac501c9d1f821eb16c2b"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_11.0.22_7_openj9-0.43.0.tar.gz"
+    version = "11.0.22"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jre"
+    name = "OpenJ9 JRE"
+    purl = "pkg:generic/ibmruntimes/semeru-jre@11.0.17?arch=arm64"
+    sha256 = "cf723eca95f805d5ba0dfc33aa798ccd9f2a1984d2dc72c0b2fed5df804e8edf"
+    source = "https://github.com/ibmruntimes/semeru11-binaries/archive/refs/tags/jdk-11.0.22+7_openj9-0.43.0.tar.gz"
+    source-sha256 = "8d30c077e9c88d9b184d23575744c462a3fbce9415d0ac501c9d1f821eb16c2b"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_11.0.22_7_openj9-0.43.0.tar.gz"
+    version = "11.0.22"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "OpenJ9 JDK"
+    purl = "pkg:generic/ibmruntimes/semeru-jdk@17.0.10?arch=arm64"
+    sha256 = "408a17ca19c74d29d60d1659e7b14bb81bb44d7f9ca992d1fd6bec96de7d9aa7"
+    source = "https://github.com/ibmruntimes/semeru17-binaries/archive/refs/tags/jdk-17.0.10+7_openj9-0.43.0.tar.gz"
+    source-sha256 = "efa6ab578a7658f9700a7ba9cb58f2db4ae2e8d5497121198b16e1b8717d89b7"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.10%2B7_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_17.0.10_7_openj9-0.43.0.tar.gz"
+    version = "17.0.10"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jre"
+    name = "OpenJ9 JRE"
+    purl = "pkg:generic/ibmruntimes/semeru-jre@17.0.10?arch=arm64"
+    sha256 = "ee2f15b9f0719eccf8e7d51404f1187c754dec55ef546b469786a72e1e9e1480"
+    source = "https://github.com/ibmruntimes/semeru17-binaries/archive/refs/tags/jdk-17.0.10+7_openj9-0.43.0.tar.gz"
+    source-sha256 = "efa6ab578a7658f9700a7ba9cb58f2db4ae2e8d5497121198b16e1b8717d89b7"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.10%2B7_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_17.0.10_7_openj9-0.43.0.tar.gz"
+    version = "17.0.10"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jdk"
+    name = "OpenJ9 JDK"
+    purl = "pkg:generic/ibmruntimes/semeru-jdk@21.0.2?arch=arm64"
+    sha256 = "6404c5fe4a71049d4f80429720b7d3f3e3b0ebea8067b823a6bfb24b9fe69797"
+    source = "https://github.com/ibmruntimes/semeru21-binaries/archive/refs/tags/jdk-21.0.2+13_openj9-0.43.0.tar.gz"
+    source-sha256 = "244e2fd808ec6a4a55e8ef28484594ead421cc00139f8294a865f9fe0a86d29f"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_21.0.2_13_openj9-0.43.0.tar.gz"
+    version = "21.0.2"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:eclipse:openj9:0.43.0:*:*:*:*:*:*:*"]
+    id = "jre"
+    name = "OpenJ9 JRE"
+    purl = "pkg:generic/ibmruntimes/semeru-jre@21.0.2?arch=arm64"
+    sha256 = "d89507e6d05132106122894b76e2e466521be047c928faf3d47827b3343c3631"
+    source = "https://github.com/ibmruntimes/semeru21-binaries/archive/refs/tags/jdk-21.0.2+13_openj9-0.43.0.tar.gz"
+    source-sha256 = "244e2fd808ec6a4a55e8ef28484594ead421cc00139f8294a865f9fe0a86d29f"
+    stacks = ["*"]
+    uri = "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_21.0.2_13_openj9-0.43.0.tar.gz"
+    version = "21.0.2"
+
+    [[metadata.dependencies.licenses]]
+      type = "EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception"
+      uri = "https://github.com/eclipse/openj9/blob/master/LICENSE"
+
 [[stacks]]
   id = "*"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/eclipse-openj9/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/helper", "bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 GOMOD=$(head -1 go.mod | awk '{print $2}')
-GOOS="linux" go build -ldflags='-s -w' -o "linux/amd64/bin/helper" "github.com/paketo-buildpacks/libjvm/cmd/helper"
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o "linux/amd64/bin/helper" "github.com/paketo-buildpacks/libjvm/cmd/helper"
 GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o "linux/arm64/bin/helper" "github.com/paketo-buildpacks/libjvm/cmd/helper"
-GOOS="linux" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
 GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,4 +24,4 @@ ln -fs main linux/arm64/bin/detect
 
 echo "END"
 ls -lR linux/
-
+ls -lR bin/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,7 +21,3 @@ ln -fs main linux/amd64/bin/build
 ln -fs main linux/arm64/bin/build
 ln -fs main linux/amd64/bin/detect
 ln -fs main linux/arm64/bin/detect
-
-echo "END"
-ls -lR linux/
-ls -lR bin/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/libjvm/cmd/helper
-GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/eclipse-openj9/v9/cmd/main
+GOMOD=$(head -1 go.mod | awk '{print $2}')
+GOOS="linux" go build -ldflags='-s -w' -o "linux/amd64/bin/helper" "github.com/paketo-buildpacks/libjvm/cmd/helper"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o "linux/arm64/bin/helper" "github.com/paketo-buildpacks/libjvm/cmd/helper"
+GOOS="linux" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/helper bin/main
+  strip linux/amd64/bin/helper linux/arm64/bin/helper
+  strip linux/amd64/bin/main linux/arm64/bin/main
 fi
 
 if [ "${COMPRESS:-none}" != "none" ]; then
-  $COMPRESS bin/helper bin/main
+  $COMPRESS linux/amd64/bin/helper linux/arm64/bin/helper
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-ln -fs main bin/build
-ln -fs main bin/detect
+ln -fs main linux/amd64/bin/build
+ln -fs main linux/arm64/bin/build
+ln -fs main linux/amd64/bin/detect
+ln -fs main linux/arm64/bin/detect

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,3 +21,7 @@ ln -fs main linux/amd64/bin/build
 ln -fs main linux/arm64/bin/build
 ln -fs main linux/amd64/bin/detect
 ln -fs main linux/arm64/bin/detect
+
+echo "END"
+ls -lR linux/
+


### PR DESCRIPTION
## Summary

There was an issue with https://github.com/paketo-buildpacks/eclipse-openj9/pull/395 which is because I accidentally merged the build script updates but we haven't added ARM64 support yet.

This adds ARM64 support so that builds work again.
